### PR TITLE
Changes to work with newer versions of areaDetector, support new devices, and simplify

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -26,7 +26,7 @@
 ##############################################################################
 
 # Define the path to the synApps support directory and uncomment.
-SUPPORT=/home/oxygen/MOONEY/epics/synAppsGIT/support
+SUPPORT=/corvette/home/epics/devel
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 
 # Specify the standard synApps configuration.
@@ -35,6 +35,17 @@ include $(SUPPORT)/configure/RELEASE
 # We might need to redefine SUPPORT and EPICS_BASE after including that file
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 -include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH) 
+
+AREA_DETECTOR=$(SUPPORT)/areaDetector-3-1
+-include $(AREA_DETECTOR)/configure/RELEASE_PATHS.local
+
+# Unfortunately RELEASE_PATHS.local above redefines SUPPORT and AREA_DETECTOR
+# and this messes things up on Windows building on a Linux host.
+# Need to redefine them as above.
+-include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
+AREA_DETECTOR=$(SUPPORT)/areaDetector-3-1
+-include $(AREA_DETECTOR)/configure/RELEASE_PATHS.local.$(EPICS_HOST_ARCH)
+-include $(AREA_DETECTOR)/configure/RELEASE_PRODS.local
 
 TDS3000 = $(SUPPORT)/../nonSynAppsSupport/tds3000-2.4
 FLY = $(SUPPORT)/../nonSynAppsSupport/fly-0-0

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -26,7 +26,7 @@
 ##############################################################################
 
 # Define the path to the synApps support directory and uncomment.
-SUPPORT=/corvette/home/epics/devel
+SUPPORT=/home/oxygen/MOONEY/epics/synAppsGIT/support
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 
 # Specify the standard synApps configuration.

--- a/xxxApp/src/Makefile
+++ b/xxxApp/src/Makefile
@@ -13,7 +13,11 @@ include $(TOP)/configure/CONFIG
 #=============================
 # build an ioc application
 
-PROD_IOC = xxx
+# PROD_NAME is used by ADCORE to add libraries
+# DBD_PREFIX is used by ADCORE to add dbd files
+PROD_NAME = xxx
+DBD_PREFIX = iocxxx
+PROD_IOC = $(PROD_NAME)
 
 # Note that the order in which .dbd files and libraries are added to a list
 # variable is important.  For .dbd files, things must be defined before they
@@ -23,422 +27,362 @@ PROD_IOC = xxx
 # Custom stuff in development
 
 ##################################################################
-# First, define xxx_Common_DBD and xxx_Common_LIBS from the modules
+# First, define $(DBD_NAME)_DBD and $(PROD_NAME)_LIBS from the modules
 # defined in RELEASE
 ##################################################################
-DBD += xxx_Common.dbd
-xxx_Common_DBD += base.dbd
+ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
+  DBD_NAME  = $(DBD_PREFIX)Win32
+endif
+ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
+  DBD_NAME  = $(DBD_PREFIX)Win64
+endif
+
+ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
+  DBD_NAME  = $(DBD_PREFIX)VX
+endif
+
+ifeq (linux,$(findstring linux, $(T_A)))
+  DBD_NAME  = $(DBD_PREFIX)Linux
+endif
+
+ifeq ($(OS_CLASS), Darwin)
+  DBD_NAME  = $(DBD_PREFIX)Darwin
+endif
+
+DBD  += $(DBD_NAME).dbd
+
+ifndef ADCORE
+  $(DBD_NAME)_DBD += base.dbd
+endif
+
+ifdef ADCORE
+  # areaDetector provides a Makefile for things it needs and supplies
+  -include $(ADCORE)/ADApp/commonDriverMakefile
+endif
 
 #ifdef TDS3000
-#	xxx_Common_DBD += devTDS3000.dbd
-#	xxx_Common_LIBS := devTDS3000 $(xxx_Common_LIBS)
+#  $(DBD_NAME)_DBD += devTDS3000.dbd
+#  $(PROD_NAME)_LIBS := devTDS3000 $($(PROD_NAME)_LIBS)
 #endif
 
 #ifdef CAPUTLOG
-#	xxx_Common_DBD += caPutLog.dbd
-#	xxx_Common_LIBS := caPutLog $(xxx_Common_LIBS)
+#  $(DBD_NAME)_DBD += caPutLog.dbd
+#  $(PROD_NAME)_LIBS := caPutLog $($(PROD_NAME)_LIBS)
 #endif
 
 ifdef CAPUTRECORDER
-	xxx_Common_DBD += caputRecorder.dbd
-	xxx_Common_LIBS := caputRecorder $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += caputRecorder.dbd
+  $(PROD_NAME)_LIBS := caputRecorder $($(PROD_NAME)_LIBS)
 endif
 
 ifdef SNCSEQ
-	ifeq (seq-2-1, $(findstring seq-2-1, $(SNCSEQ)))
-		xxx_Common_DBD += devSequencer.dbd
-		xxx_Common_LIBS := seqDev seq pv $(xxx_Common_LIBS)
-	else ifeq (seq-2.1, $(findstring seq-2.1, $(SNCSEQ)))
-		xxx_Common_DBD += devSequencer.dbd
-		xxx_Common_LIBS := seqDev seq pv $(xxx_Common_LIBS)
-	else
-		# seq 2.2.
-		xxx_Common_LIBS := seq pv $(xxx_Common_LIBS)
-	endif
+  ifeq (seq-2-1, $(findstring seq-2-1, $(SNCSEQ)))
+    $(DBD_NAME)_DBD += devSequencer.dbd
+    $(PROD_NAME)_LIBS := seqDev seq pv $($(PROD_NAME)_LIBS)
+  else ifeq (seq-2.1, $(findstring seq-2.1, $(SNCSEQ)))
+    $(DBD_NAME)_DBD += devSequencer.dbd
+    $(PROD_NAME)_LIBS := seqDev seq pv $($(PROD_NAME)_LIBS)
+  else
+    # seq 2.2.
+    $(PROD_NAME)_LIBS := seq pv $($(PROD_NAME)_LIBS)
+  endif
 endif
 
 ifdef ASYN
-	xxx_Common_DBD += asyn.dbd drvAsynSerialPort.dbd
-	xxx_Common_DBD += drvAsynIPPort.dbd drvVxi11.dbd devGpib.dbd
-	xxx_Common_LIBS := asyn $(xxx_Common_LIBS)
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += asyn.dbd
+  endif
+  $(DBD_NAME)_DBD += drvAsynSerialPort.dbd drvAsynIPPort.dbd drvVxi11.dbd devGpib.dbd
+  $(PROD_NAME)_LIBS := asyn $($(PROD_NAME)_LIBS)
 endif
 
 ifdef STD
-	xxx_Common_DBD += stdSupport.dbd
-	xxx_Common_LIBS := std $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += stdSupport.dbd
+  $(PROD_NAME)_LIBS := std $($(PROD_NAME)_LIBS)
 endif
 
 ifdef CALC
-	xxx_Common_DBD += calcSupport.dbd
-	xxx_Common_LIBS := calc $(xxx_Common_LIBS)
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += calcSupport.dbd
+  endif
+  $(PROD_NAME)_LIBS := calc $($(PROD_NAME)_LIBS)
 endif
 
 ifdef BUSY
-	xxx_Common_DBD += busySupport.dbd
-	xxx_Common_LIBS := busy $(xxx_Common_LIBS)
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += busySupport.dbd
+  endif
+  $(PROD_NAME)_LIBS := busy $($(PROD_NAME)_LIBS)
 endif
 
 ifdef SSCAN
-	xxx_Common_DBD += sscanSupport.dbd
-	xxx_Common_LIBS := sscan $(xxx_Common_LIBS)
-	ifdef SNCSEQ
-		xxx_Common_DBD += sscanProgressSupport.dbd
-		xxx_Common_LIBS := scanProgress $(xxx_Common_LIBS)
-	endif
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += sscanSupport.dbd
+  endif
+  $(PROD_NAME)_LIBS := sscan $($(PROD_NAME)_LIBS)
+  ifdef SNCSEQ
+    $(DBD_NAME)_DBD += sscanProgressSupport.dbd
+    $(PROD_NAME)_LIBS := scanProgress $($(PROD_NAME)_LIBS)
+  endif
 endif
 
 ifdef AUTOSAVE
-	xxx_Common_DBD += asSupport.dbd
-	xxx_Common_LIBS := autosave $(xxx_Common_LIBS)
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += asSupport.dbd
+  endif
+  $(PROD_NAME)_LIBS := autosave $($(PROD_NAME)_LIBS)
 endif
 
 ifdef OPTICS
-	xxx_Common_DBD += opticsSupport.dbd
-	xxx_Common_LIBS := optics $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += opticsSupport.dbd
+  $(PROD_NAME)_LIBS := optics $($(PROD_NAME)_LIBS)
 endif
 
 ifdef MCA
-	xxx_Common_DBD += mcaSupport.dbd
-	xxx_Common_LIBS := mca $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += mcaSupport.dbd
+  $(PROD_NAME)_LIBS := mca $($(PROD_NAME)_LIBS)
+endif
+
+ifdef QUADEM
+  $(DBD_NAME)_DBD += drvAHxxx.dbd drvTetrAMM.dbd
+  $(PROD_NAME)_LIBS := quadEM $($(PROD_NAME)_LIBS)
 endif
 
 ifdef IP
-	xxx_Common_DBD += ipSupport.dbd
-	xxx_Common_LIBS := ip $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += ipSupport.dbd
+  $(PROD_NAME)_LIBS := ip $($(PROD_NAME)_LIBS)
 endif
 
 ifdef MODBUS
-	xxx_Common_DBD += modbusSupport.dbd
-	xxx_Common_LIBS := modbus $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += modbusSupport.dbd
+  $(PROD_NAME)_LIBS := modbus $($(PROD_NAME)_LIBS)
 endif
 
 ifdef MOTOR
-	xxx_Common_DBD += motorSupport.dbd devAcsMotor.dbd devAerotech.dbd
-	xxx_Common_DBD += devAttocube.dbd devFaulhaberMotor.dbd devImsMotor.dbd
-	xxx_Common_DBD += devKohzuMotor.dbd devMclennanMotor.dbd devMicos.dbd
-	xxx_Common_DBD += devMicroMo.dbd devNewFocus.dbd devNewport.dbd
+  $(DBD_NAME)_DBD += motorSupport.dbd devAcsMotor.dbd devAerotech.dbd
+  $(DBD_NAME)_DBD += devAttocube.dbd devFaulhaberMotor.dbd devImsMotor.dbd
+  $(DBD_NAME)_DBD += devKohzuMotor.dbd devMclennanMotor.dbd devMicos.dbd
+  $(DBD_NAME)_DBD += devMicroMo.dbd devNewFocus.dbd devNewport.dbd
   ifdef SNCSEQ
-	xxx_Common_DBD += devAerotechSeq.dbd devNewportSeq.dbd
+  $(DBD_NAME)_DBD += devAerotechSeq.dbd devNewportSeq.dbd
   endif
-	xxx_Common_DBD += devOriel.dbd devPC6K.dbd devPIJena.dbd devPIMotor.dbd
-	xxx_Common_DBD += devSPiiPlus.dbd devSmartMotorMotor.dbd devSoftMotor.dbd
-	xxx_Common_DBD += devThorLabs.dbd motorSimSupport.dbd
+  $(DBD_NAME)_DBD += devOriel.dbd devPC6K.dbd devPIJena.dbd devPIMotor.dbd
+  $(DBD_NAME)_DBD += devSPiiPlus.dbd devSmartMotorMotor.dbd devSoftMotor.dbd
+  $(DBD_NAME)_DBD += devThorLabs.dbd motorSimSupport.dbd
 
-	xxx_Common_LIBS := motor $(xxx_Common_LIBS)
-	xxx_Common_LIBS := Acs acsTech80 Aerotech Attocube Faulhaber Ims KohzuMotor $(xxx_Common_LIBS)
-	xxx_Common_LIBS := Mclennan Micos MicroMo NewFocus Newport Oriel PI PIJena $(xxx_Common_LIBS)
-	xxx_Common_LIBS := Parker SmartMotor ThorLabs softMotor motorSimSupport $(xxx_Common_LIBS)
+  $(PROD_NAME)_LIBS := motor $($(PROD_NAME)_LIBS)
+  $(PROD_NAME)_LIBS := Acs acsTech80 Aerotech Attocube Faulhaber Ims KohzuMotor $($(PROD_NAME)_LIBS)
+  $(PROD_NAME)_LIBS := Mclennan Micos MicroMo NewFocus Newport Oriel PI PIJena $($(PROD_NAME)_LIBS)
+  $(PROD_NAME)_LIBS := Parker SmartMotor ThorLabs softMotor motorSimSupport $($(PROD_NAME)_LIBS)
 endif
 
 ifdef STREAM
-	xxx_Common_DBD += stream.dbd streamSynApps.dbd
-	xxx_Common_LIBS := stream streamSynApps $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += stream.dbd streamSynApps.dbd
+  $(PROD_NAME)_LIBS := stream streamSynApps $($(PROD_NAME)_LIBS)
 endif
 
 ifdef DEVIOCSTATS
-	xxx_Common_DBD += devIocStats.dbd iocAdmin.dbd
-	xxx_Common_LIBS := devIocStats $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += devIocStats.dbd iocAdmin.dbd
+  $(PROD_NAME)_LIBS := devIocStats $($(PROD_NAME)_LIBS)
 endif
 
 ifdef ETHERIP
-	xxx_Common_DBD += ether_ip.dbd
-	xxx_Common_LIBS := ether_ip $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += ether_ip.dbd
+  $(PROD_NAME)_LIBS := ether_ip $($(PROD_NAME)_LIBS)
 endif
 
 ifdef ALIVE
-	xxx_Common_DBD += aliveSupport.dbd
-	xxx_Common_LIBS := alive $(xxx_Common_LIBS)
+  ifndef ADCORE
+    $(DBD_NAME)_DBD += aliveSupport.dbd
+  endif
+  $(PROD_NAME)_LIBS := alive $($(PROD_NAME)_LIBS)
 endif
 
 ifdef DELAYGEN
-	xxx_Common_DBD += delaygenSupport.dbd
-	xxx_Common_LIBS := delaygen $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += delaygenSupport.dbd
+  $(PROD_NAME)_LIBS := delaygen $($(PROD_NAME)_LIBS)
 endif
 
 ifdef VAC
-	xxx_Common_DBD += vacSupport.dbd
-	xxx_Common_LIBS := vac $(xxx_Common_LIBS)
+  $(DBD_NAME)_DBD += vacSupport.dbd
+  $(PROD_NAME)_LIBS := vac $($(PROD_NAME)_LIBS)
 endif
 
 #ifdef FLY
-#	xxx_Common_DBD += flySupport.dbd
-#	xxx_Common_LIBS := fly $(xxx_Common_LIBS)
+#  $(DBD_NAME)_DBD += flySupport.dbd
+#  $(PROD_NAME)_LIBS := fly $($(PROD_NAME)_LIBS)
 #endif
 
-xxx_Common_LIBS := $(xxx_Common_LIBS) $(EPICS_BASE_IOC_LIBS)
 
 ##################################################################
 
 
 ifeq (win32-x86,$(findstring win32-x86, $(T_A)))
+  ifdef MCA
+    # If your host supports libpcap and libnet and you want to build
+    # Canberra network support uncomment the following lines
+    #$(DBD_NAME)_DBD += mcaCanberraSupport.dbd
+    #$(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
+    #$(PROD_NAME)_LIBS := wpcap Packet $($(PROD_NAME)_LIBS)
 
-	DBD  += iocxxxWin32.dbd
-	iocxxxWin32_DBD += xxx_Common.dbd
+    $(DBD_NAME)_DBD += mcaAmptekSupport.dbd
+    $(PROD_NAME)_LIBS := mcaAmptek $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_LIBS := libusb-1.0 $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef MCA
-		# If your host supports libpcap and libnet and you want to build
-		# Canberra network support uncomment the following lines
-		#iocxxxWin32_DBD += mcaCanberraSupport.dbd
-		#xxx_LIBS_WIN32 += mcaCanberra
-		#xxx_LIBS_WIN32 += wpcap Packet
-	endif
-
-	ifdef DXP
-		# If you want to build parallel port or USB interfaces to Saturn and/or
-		# xMAP DXP, then uncomment the following lines
-		iocxxxWin32_DBD += dxpSupport.dbd
-		xxx_LIBS_WIN32 += dxp handel
-		xxx_LIBS_WIN32 += DLPORTIO PlxApi
-		xxx_SYS_LIBS_WIN32 += setupapi
-	endif
-
-	ifdef AREA_DETECTOR
-		# areaDetector provides a Makefile for things it needs and supplies
-		PROD_NAME = AD
-		-include $(ADCORE)/ADApp/commonDriverMakefile
-		iocxxxWin32_DBD += ADSupport.dbd NDPluginSupport.dbd
-		xxx_LIBS_WIN32 += $(AD_LIBS)
-		ifdef ADEXAMPLE
-			# To add the simDetector uncomment the following lines
-			iocxxxLinux_DBD += simDetectorSupport.dbd
-			xxx_LIBS_WIN32 += simDetector
-		endif
-	endif
+  ifdef DXP
+    # If you want to build parallel port or USB interfaces to Saturn and/or
+    # xMAP DXP, then uncomment the following lines
+    $(DBD_NAME)_DBD += dxpSupport.dbd
+    $(PROD_NAME)_LIBS := dxp handel $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_LIBS := DLPORTIO PlxApi $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_SYS_LIBS += setupapi
+  endif
 endif
 
 ifeq (windows-x64,$(findstring windows-x64, $(T_A)))
-	DBD  += iocxxxWin64.dbd
-	iocxxxWin64_DBD += xxx_Common.dbd
+  ifdef MCA
+    # If your host supports libpcap and libnet and you want to build Canberra network
+    # support uncomment the following line
+    $(DBD_NAME)_DBD += mcaCanberraSupport.dbd
+    $(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_LIBS := wpcap Packet $($(PROD_NAME)_LIBS)
 
-	ifdef MCA
-		# If your host supports libpcap and libnet and you want to build Canberra network
-		# support uncomment the following line
-		iocxxxWin64_DBD += mcaCanberraSupport.dbd
-		xxx_LIBS_WIN32 += mcaCanberra
-		xxx_LIBS_WIN32 += wpcap Packet
-	endif
-
-	ifdef AREA_DETECTOR
-		# areaDetector provides a Makefile for things it needs and supplies
-		PROD_NAME = AD
-		-include $(ADCORE)/ADApp/commonDriverMakefile
-		iocxxxWin64_DBD += ADSupport.dbd NDPluginSupport.dbd
-		xxx_LIBS_WIN32 += $(AD_LIBS)
-		# To add the simDetector uncomment the following lines
-		iocxxxLinux_DBD += simDetectorSupport.dbd
-		xxx_LIBS_WIN32 += simDetector
-	endif
-endif
-
-ifeq ($(EPICS_HOST_ARCH), cygwin-x86)
-	DBD  += iocxxxCygwin.dbd
-	iocxxxCygwin_DBD += xxx_Common.dbd
-
-	ifdef DXP
-		# If you want to build parallel port or USB interfaces to Saturn and/or
-		# xMAP DXP,then uncomment the following lines
-		#iocxxxCygwin_DBD += dxpSupport.dbd
-		#xxx_LIBS_cygwin32 += dxp handel
-		#xxx_SYS_LIBS_cygwin32 += DLPORTIO PlxApi setupapi
-	endif
-
-	xxx_SYS_LIBS_cygwin32 += $(CYGWIN_RPC_LIB)
-
+    $(DBD_NAME)_DBD += mcaAmptekSupport.dbd
+    $(PROD_NAME)_LIBS := mcaAmptek $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_LIBS := libusb-1.0 $($(PROD_NAME)_LIBS)
+  endif
 endif
 
 ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
-	DBD  += iocxxxVX.dbd
-	iocxxxVX_DBD += xxx_Common.dbd
+  ifdef ALLEN_BRADLEY
+    $(PROD_NAME)_LIBS := allenBradley $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef ALLEN_BRADLEY
-		xxx_LIBS_vxWorks += allenBradley
-	endif
+  ifdef VME
+    $(DBD_NAME)_DBD += vmeVXSupport.dbd
+    $(PROD_NAME)_LIBS := vme $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef QUADEM
-		iocxxxVX_DBD += drvAHxxx.dbd
-		iocxxxVX_DBD += drvAPS_EM.dbd
-		xxx_LIBS_vxWorks += quadEM
-	endif
+  ifdef STD
+    $(DBD_NAME)_DBD += stdVXSupport.dbd
+  endif
 
-	ifdef AREA_DETECTOR
-		# areaDetector provides a Makefile for things it needs and supplies
-		PROD_NAME = AD
-		-include $(ADCORE)/ADApp/commonDriverMakefile
-		iocxxxVX_DBD += ADSupport.dbd NDPluginSupport.dbd
-		xxx_LIBS_vxWorks += $(AD_LIBS)
-		# To add the simDetector uncomment the following lines
-		iocxxxVX_DBD += simDetectorSupport.dbd
-		xxx_LIBS_vxWorks += simDetector
-	endif
+  ifdef IP
+    $(DBD_NAME)_DBD += ipVXSupport.dbd
+  endif
 
-	ifdef VME
-		iocxxxVX_DBD += vmeVXSupport.dbd
-		xxx_LIBS_vxWorks += vme
-	endif
+  ifdef MCA
+    $(DBD_NAME)_DBD += SIS38XXSupport.dbd
+    $(DBD_NAME)_DBD += mcaCanberraSupport.dbd
+    $(PROD_NAME)_LIBS := SIS38XX $($(PROD_NAME)_LIBS)
+    $(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef STD
-		iocxxxVX_DBD += stdVXSupport.dbd
-	endif
+  ifdef IPUNIDIG
+    $(DBD_NAME)_DBD += ipUnidigSupport.dbd
+    $(PROD_NAME)_LIBS := ipUnidig $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef IP
-		iocxxxVX_DBD += ipVXSupport.dbd
-	endif
+  ifdef DAC128V
+    $(DBD_NAME)_DBD += dac128VSupport.dbd
+    $(PROD_NAME)_LIBS := dac128V $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef MCA
-		iocxxxVX_DBD += SIS38XXSupport.dbd
-		iocxxxVX_DBD += mcaCanberraSupport.dbd
-		xxx_LIBS_vxWorks += SIS38XX
-		xxx_LIBS_vxWorks += mcaCanberra
-	endif
+  ifdef IP330
+    $(DBD_NAME)_DBD += ip330Support.dbd
+    $(PROD_NAME)_LIBS := ip330 $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef IPUNIDIG
-		iocxxxVX_DBD += ipUnidigSupport.dbd
-		xxx_LIBS_vxWorks += ipUnidig
-	endif
+  ifdef CAMAC
+    $(DBD_NAME)_DBD += camacSupport.dbd
+    $(DBD_NAME)_DBD += devCamacSupport.dbd
+    $(PROD_NAME)_LIBS := camac devCamac $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef DAC128V
-		iocxxxVX_DBD += dac128VSupport.dbd
-		xxx_LIBS_vxWorks += dac128V
-	endif
+  ifdef ALLEN_BRADLEY
+    $(DBD_NAME)_DBD += allenBradley.dbd
+  endif
 
-	ifdef IP330
-		iocxxxVX_DBD += ip330Support.dbd
-		xxx_LIBS_vxWorks += ip330
-	endif
+  ifdef LOVE
+    $(DBD_NAME)_DBD += devLove.dbd
+    $(PROD_NAME)_LIBS := love $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef CAMAC
-		iocxxxVX_DBD += camacSupport.dbd
-		iocxxxVX_DBD += devCamacSupport.dbd
-		xxx_LIBS_vxWorks += camac devCamac
-	endif
+  ifdef IPAC
+    $(DBD_NAME)_DBD += tyGSOctal.dbd
+    $(DBD_NAME)_DBD += drvIpac.dbd
+    $(PROD_NAME)_LIBS := TyGSOctal Ipac $($(PROD_NAME)_LIBS)
+    $(DBD_NAME)_DBD += IP520.dbd
+    $(PROD_NAME)_LIBS := IP520 $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef ALLEN_BRADLEY
-		iocxxxVX_DBD += allenBradley.dbd
-	endif
+  ifdef ASYN
+    $(DBD_NAME)_DBD += drvGsIP488.dbd
+  endif
 
-	ifdef LOVE
-		iocxxxVX_DBD += devLove.dbd
-		xxx_LIBS_vxWorks += love
-	endif
+  ifdef SOFTGLUE
+    $(DBD_NAME)_DBD += softGlueSupport.dbd
+    $(PROD_NAME)_LIBS := softGlue $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef IPAC
-		iocxxxVX_DBD += tyGSOctal.dbd
-		iocxxxVX_DBD += drvIpac.dbd
-		xxx_LIBS_vxWorks += TyGSOctal Ipac
-		iocxxxVX_DBD += IP520.dbd
-		xxx_LIBS_vxWorks += IP520
-	endif
+  ifdef MOTOR
+    $(DBD_NAME)_DBD += devDeltaTau.dbd
+    $(DBD_NAME)_DBD += devOms.dbd
+    $(PROD_NAME)_LIBS := oms DeltaTau $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef ASYN
-		iocxxxVX_DBD += drvGsIP488.dbd
-	endif
-
-	ifdef SOFTGLUE
-		iocxxxVX_DBD += softGlueSupport.dbd
-		xxx_LIBS_vxWorks += softGlue
-	endif
-
-	ifdef MOTOR
-		iocxxxVX_DBD += devDeltaTau.dbd
-		iocxxxVX_DBD += devOms.dbd
-		xxx_LIBS_vxWorks += oms DeltaTau
-	endif
-
-#	ifdef FLY
-#		iocxxxVX_DBD += flyVXSupport.dbd
-#		xxx_LIBS_vxWorks += fly
-#	endif
+#  ifdef FLY
+#    $(DBD_NAME)_DBD += flyVXSupport.dbd
+#    $(PROD_NAME)_LIBS := fly $($(PROD_NAME)_LIBS)
+#  endif
 
 endif
 
 ifneq (,$(findstring linux, $(T_A)))
-	DBD  += iocxxxLinux.dbd
-	iocxxxLinux_DBD += xxx_Common.dbd
+  ifdef DXP
+    # If your host supports parallel port or USB interfaces to Saturn DXP, set
+    # LINUX_USB_INSTALLED to YES in <synApps>/configure/CONFIG_SITE.
+    ifeq ($(LINUX_USB_INSTALLED), YES)
+      $(DBD_NAME)_DBD += dxpSupport.dbd
+      $(PROD_NAME)_LIBS  := dxp handel $($(PROD_NAME)_LIBS)
+      $(PROD_NAME)_SYS_LIBS += usb 
+    endif
+  endif
 
-ifeq ($(HAVE_HDF5), YES)
-ifeq ($(HAVE_SZIP), YES)
+  ifdef MCA
+    # If your host supports libpcap and libnet and you want to build Canberra network
+    # support, set LINUX_NET_INSTALLED to YES in <synApps>/configure/CONFIG_SITE.
+    ifeq ($(LINUX_NET_INSTALLED), YES)
+      $(DBD_NAME)_DBD += mcaCanberraSupport.dbd
+      $(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
+      $(PROD_NAME)_SYS_LIBS += net pcap
+    endif
+  endif
 
-	ifdef QUADEM
-		iocxxxLinux_DBD += drvAHxxx.dbd
-		xxx_LIBS_Linux += quadEM
-	endif
+  ifdef IPAC
+    $(DBD_NAME)_DBD += drvIpac.dbd
+    $(PROD_NAME)_LIBS := Ipac $($(PROD_NAME)_LIBS)
+  endif
 
-	ifdef AREA_DETECTOR
-		# areaDetector provides a Makefile for things it needs and supplies
-		PROD_NAME = AD
-		-include $(ADCORE)/ADApp/commonDriverMakefile
-		iocxxxLinux_DBD += ADSupport.dbd NDPluginSupport.dbd
-		xxx_LIBS_Linux += $(AD_LIBS)
-		# To add the simDetector uncomment the following lines
-		iocxxxLinux_DBD += simDetectorSupport.dbd
-		xxx_LIBS_Linux += simDetector
-	endif
-
-	ifdef DXP
-		# If your host supports parallel port or USB interfaces to Saturn DXP, set
-		# LINUX_USB_INSTALLED to YES in <synApps>/configure/CONFIG_SITE.
-		ifeq ($(LINUX_USB_INSTALLED), YES)
-			iocxxxLinux_DBD += dxpSupport.dbd
-			xxx_LIBS_Linux  += dxp handel
-			xxx_SYS_LIBS_Linux += usb
-		endif
-	endif
-
-endif
+  ifdef SOFTGLUE
+    $(DBD_NAME)_DBD += softGlueSupport.dbd
+    $(PROD_NAME)_LIBS := softGlue $($(PROD_NAME)_LIBS)
+  endif
 endif
 
-	ifdef MCA
-		# If your host supports libpcap and libnet and you want to build Canberra network
-		# support, set LINUX_NET_INSTALLED to YES in <synApps>/configure/CONFIG_SITE.
-		ifeq ($(LINUX_NET_INSTALLED), YES)
-			iocxxxLinux_DBD += mcaCanberraSupport.dbd
-			xxx_LIBS_Linux += mcaCanberra
-			xxx_SYS_LIBS_Linux += net pcap
-		endif
-	endif
-
-	ifdef IPAC
-		iocxxxLinux_DBD += drvIpac.dbd
-		xxx_LIBS_Linux += Ipac
-	endif
-
-	ifdef SOFTGLUE
-		iocxxxLinux_DBD += softGlueSupport.dbd
-		xxx_LIBS_Linux += softGlue
-	endif
-endif
-
-ifeq ($(OS_CLASS), Darwin)
-	DBD  += iocxxxDarwin.dbd
-	iocxxxDarwin_DBD += xxx_Common.dbd
-endif
-
-
+$(PROD_NAME)_LIBS := $($(PROD_NAME)_LIBS) $(EPICS_BASE_IOC_LIBS)
 
 # <name>_registerRecordDeviceDriver.cpp will be created from <name>.dbd
-xxx_SRCS_vxWorks  += iocxxxVX_registerRecordDeviceDriver.cpp
-xxx_SRCS_Linux    += iocxxxLinux_registerRecordDeviceDriver.cpp     xxxMain.cpp
-ifeq (win32-x86,$(findstring win32-x86, $(T_A)))
-	xxx_SRCS_WIN32    += iocxxxWin32_registerRecordDeviceDriver.cpp     xxxMain.cpp
-endif
-ifeq (windows-x64,$(findstring windows-x64, $(T_A)))
-	xxx_SRCS_WIN32    += iocxxxWin64_registerRecordDeviceDriver.cpp     xxxMain.cpp
-endif
-xxx_SRCS_cygwin32 += iocxxxCygwin_registerRecordDeviceDriver.cpp    xxxMain.cpp
-xxx_SRCS_solaris  += iocxxx_solaris_registerRecordDeviceDriver.cpp  xxxMain.cpp
-xxx_SRCS_Darwin   += iocxxxDarwin_registerRecordDeviceDriver.cpp    xxxMain.cpp
-
-
+$(PROD_NAME)_SRCS_vxWorks  += $(DBD_NAME)_registerRecordDeviceDriver.cpp
+$(PROD_NAME)_SRCS_Linux    += $(DBD_NAME)_registerRecordDeviceDriver.cpp    $(PROD_NAME)Main.cpp
+$(PROD_NAME)_SRCS_WIN32    += $(DBD_NAME)_registerRecordDeviceDriver.cpp    $(PROD_NAME)Main.cpp
+$(PROD_NAME)_SRCS_cygwin32 += $(DBD_NAME)_registerRecordDeviceDriver.cpp    $(PROD_NAME)Main.cpp
+$(PROD_NAME)_SRCS_solaris  += $(DBD_NAME)_registerRecordDeviceDriver.cpp    $(PROD_NAME)Main.cpp
+$(PROD_NAME)_SRCS_Darwin   += $(DBD_NAME)_registerRecordDeviceDriver.cpp    $(PROD_NAME)Main.cpp
 
 #The following adds support from base/src/vxWorks
-xxx_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
-
-xxx_LIBS_vxWorks  += $(xxx_Common_LIBS)
-xxx_LIBS_Linux    += $(xxx_Common_LIBS)
-xxx_LIBS_solaris  += $(xxx_Common_LIBS)
-xxx_LIBS_cygwin32 += $(xxx_Common_LIBS)
-xxx_LIBS_WIN32    += $(xxx_Common_LIBS)
-xxx_LIBS_Darwin   += $(xxx_Common_LIBS)
+$(PROD_NAME)_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
 
 # Here's how to print out all gnumake variables
 #$(foreach v, $(.VARIABLES), $(info $(v) = $($(v))))
@@ -450,24 +394,3 @@ xxx_LIBS_Darwin   += $(xxx_Common_LIBS)
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
-
-$(COMMON_DIR)/iocxxxWin32Include.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxWin64Include.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxCygwinInclude.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxVXInclude.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxLinuxInclude.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxDarwinInclude.dbd: $(COMMON_DIR)/xxx_Common.dbd
-
-$(COMMON_DIR)/iocxxxWin32.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxWin64.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxCygwin.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxVX.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxLinux.dbd: $(COMMON_DIR)/xxx_Common.dbd
-$(COMMON_DIR)/iocxxxDarwin.dbd: $(COMMON_DIR)/xxx_Common.dbd
-
-iocxxxWin32.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd
-iocxxxWin64.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd
-iocxxxCygwin.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd
-iocxxxVX.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd
-iocxxxLinux.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd
-iocxxxDarwin.dbd$(DEP): $(COMMON_DIR)/xxx_Common.dbd

--- a/xxxApp/src/Makefile
+++ b/xxxApp/src/Makefile
@@ -358,6 +358,14 @@ ifneq (,$(findstring linux, $(T_A)))
       $(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
       $(PROD_NAME)_SYS_LIBS += net pcap
     endif
+
+    # If your host supports libusb-1.0 and you want to build Amptek
+    # support, set LINUX_USB-1.0_INSTALLED to YES in <synApps>/configure/CONFIG_SITE.
+    ifeq ($(LINUX_USB-1.0_INSTALLED), YES)
+      $(DBD_NAME)_DBD += mcaAmptekSupport.dbd
+      $(PROD_NAME)_LIBS := mcaAmptek $($(PROD_NAME)_LIBS)
+      $(PROD_NAME)_SYS_LIBS += usb-1.0
+    endif
   endif
 
   ifdef IPAC

--- a/xxxApp/src/Makefile
+++ b/xxxApp/src/Makefile
@@ -32,9 +32,11 @@ PROD_IOC = $(PROD_NAME)
 ##################################################################
 ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
   DBD_NAME  = $(DBD_PREFIX)Win32
+  WINDOWS_TARGET = YES
 endif
 ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
   DBD_NAME  = $(DBD_PREFIX)Win64
+  WINDOWS_TARGET = YES
 endif
 
 ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
@@ -215,35 +217,20 @@ endif
 
 
 ##################################################################
+ifdef WINDOWS_TARGET
+  ifdef MEASCOMP
+    $(DBD_NAME)_DBD += measCompSupport.dbd
+    $(PROD_NAME)_LIBS := measComp $($(PROD_NAME)_LIBS)
+    ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
+      $(PROD_NAME)_LIBS := cbw32 $($(PROD_NAME)_LIBS)
+    else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
+      $(PROD_NAME)_LIBS := cbw64 $($(PROD_NAME)_LIBS)
+    endif
+  endif
 
-
-ifeq (win32-x86,$(findstring win32-x86, $(T_A)))
   ifdef MCA
-    # If your host supports libpcap and libnet and you want to build
+    # If you have installed WinPcap (https://www.winpcap.org) and you want to build
     # Canberra network support uncomment the following lines
-    #$(DBD_NAME)_DBD += mcaCanberraSupport.dbd
-    #$(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
-    #$(PROD_NAME)_LIBS := wpcap Packet $($(PROD_NAME)_LIBS)
-
-    $(DBD_NAME)_DBD += mcaAmptekSupport.dbd
-    $(PROD_NAME)_LIBS := mcaAmptek $($(PROD_NAME)_LIBS)
-    $(PROD_NAME)_LIBS := libusb-1.0 $($(PROD_NAME)_LIBS)
-  endif
-
-  ifdef DXP
-    # If you want to build parallel port or USB interfaces to Saturn and/or
-    # xMAP DXP, then uncomment the following lines
-    $(DBD_NAME)_DBD += dxpSupport.dbd
-    $(PROD_NAME)_LIBS := dxp handel $($(PROD_NAME)_LIBS)
-    $(PROD_NAME)_LIBS := DLPORTIO PlxApi $($(PROD_NAME)_LIBS)
-    $(PROD_NAME)_SYS_LIBS += setupapi
-  endif
-endif
-
-ifeq (windows-x64,$(findstring windows-x64, $(T_A)))
-  ifdef MCA
-    # If your host supports libpcap and libnet and you want to build Canberra network
-    # support uncomment the following line
     $(DBD_NAME)_DBD += mcaCanberraSupport.dbd
     $(PROD_NAME)_LIBS := mcaCanberra $($(PROD_NAME)_LIBS)
     $(PROD_NAME)_LIBS := wpcap Packet $($(PROD_NAME)_LIBS)
@@ -252,8 +239,20 @@ ifeq (windows-x64,$(findstring windows-x64, $(T_A)))
     $(PROD_NAME)_LIBS := mcaAmptek $($(PROD_NAME)_LIBS)
     $(PROD_NAME)_LIBS := libusb-1.0 $($(PROD_NAME)_LIBS)
   endif
+
+  ifeq (win32-x86,$(findstring win32-x86, $(T_A)))
+    ifdef DXP
+      # If you want to build parallel port or USB interfaces to Saturn and/or
+      # xMAP DXP, then uncomment the following lines
+      $(DBD_NAME)_DBD += dxpSupport.dbd
+      $(PROD_NAME)_LIBS := dxp handel $($(PROD_NAME)_LIBS)
+      $(PROD_NAME)_LIBS := DLPORTIO PlxApi $($(PROD_NAME)_LIBS)
+      $(PROD_NAME)_SYS_LIBS += setupapi
+    endif
+  endif
 endif
 
+##################################################################
 ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
   ifdef ALLEN_BRADLEY
     $(PROD_NAME)_LIBS := allenBradley $($(PROD_NAME)_LIBS)
@@ -339,6 +338,7 @@ ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
 
 endif
 
+##################################################################
 ifneq (,$(findstring linux, $(T_A)))
   ifdef DXP
     # If your host supports parallel port or USB interfaces to Saturn DXP, set
@@ -363,6 +363,21 @@ ifneq (,$(findstring linux, $(T_A)))
   ifdef IPAC
     $(DBD_NAME)_DBD += drvIpac.dbd
     $(PROD_NAME)_LIBS := Ipac $($(PROD_NAME)_LIBS)
+  endif
+
+  ifdef IPUNIDIG
+    $(DBD_NAME)_DBD += ipUnidigSupport.dbd
+    $(PROD_NAME)_LIBS := ipUnidig $($(PROD_NAME)_LIBS)
+  endif
+
+  ifdef DAC128V
+    $(DBD_NAME)_DBD += dac128VSupport.dbd
+    $(PROD_NAME)_LIBS := dac128V $($(PROD_NAME)_LIBS)
+  endif
+
+  ifdef IP330
+    $(DBD_NAME)_DBD += ip330Support.dbd
+    $(PROD_NAME)_LIBS := ip330 $($(PROD_NAME)_LIBS)
   endif
 
   ifdef SOFTGLUE


### PR DESCRIPTION
Changes to work with newer versions of areaDetector, support new devices, and simplify.

This pull request changes 2 files:
- configure/RELEASE adds some lines to pull in definitions from areaDetector
- xxxApp/src/Makefile has many changes described in detail below.

Changes to Makefile:
- All instances of xxx_Common_LIBS and xxx_LIBS_[ARCH] are changed to $(PROD_NAME)_LIBS.  This has a number of advantages:
  - It makes it easy to compare Makefiles derived from that in xxx with new versions of the one in xxx, since it is just the definition of $(PROD_NAME) which changes, not lots of lines in the file.
  - It is simpler because we are not assembling xxx_Common_LIBS and then appending that to the architecture specific library variable.  We just build a single variable, using the same syntax in the entire file.
  - PROD_NAME is required anyway if invoking ADCORE/ADApp/commonDriverMakefile.

- All instances of xxx_Common_DBD and iocxxx[ARCH]_DBD are changed to $(DBD_NAME)_DBD.  This has a number of advantages:
  - DBD_NAME is created from DBD_PREFIX by appending Win32, Linux, VX, vxWorks, etc.  This is done at the beginning of the Makefile.
  - It makes it easy to compare Makefiles derived from that in xxx with new versions of the one in xxx, since it is just the definition of $(DBD_PREFIX) which changes, not lots of lines in the file.
  - It is simpler because we are not assembling xxx_Common_DBD and then prepending that to the architecture specific library variable.  We just build a single variable, using the same syntax in the entire file.  
  - Because we are not using xxx_Common_DBD we can remove all of the special RULES at the end of the Makefile.
  - DBD_NAME is required anyway if invoking ADCORE/ADApp/commonDriverMakefile.

- Added support for Measurement Computing devices on Windows

- Added support for Amptek MCAs on Linux and Windows

- Added support for DAC128V, IPUNIDIG, and IP330 on Linux.

- Simplified the Windows support by removing the duplicate entries for 32 and 64 bit versions where possible.

- ADCORE/ADApp/commonDriverMakefile adds a number of DBD files to $(DBD_NAME)_DBD.  These include not only things from areaDetector, but also base.dbd, asyn.dbd, calcSupport.dbd, etc.  This means that this Makefile needs to contain code like the following. 
```
  ifndef ADCORE
    $(DBD_NAME)_DBD += asyn.dbd
  endif
```
- This is because on base 3.15 one cannot have duplicate entries in dbd files.  It makes this Makefile a bit fragile because:
    - It assumes that the same modules are defined in the xxx/configure/RELEASE file as are defined in area/configure/RELEASE*.local files, i.e. if ALIVE is defined in one location it is also defined in the other.
    - This Makefile needs to know what modules areaDetector uses.  areaDetector currently always uses base and asyn, and optionally uses autosave, busy, calc, sscan, seq, sscan, devIocStats, and alive.  
The alternative to using commonDriverMakefile is to duplicate a lot of code in this Makefile, which is much more fragile.
- areaDetector and quadEM are now optionally included on all architectures, not just on Linux and Windows.  On Linux the dependencies on HAVE_HDF5 and HAVE_SZIP are no longer needed and have been removed.
- Cygwin support has been removed.  Cygwin is no longer useful, because it cannot handle Windows .lib files from vendors which older versions did, so it cannot be used with any real device support.

This is now the difference between the Makefile in XXX and the one in by CARS directory for building all of the IOCs at sector 13.  Note that there are very few differences except for my local SNL programs.  This makes it easy to modify when XXX is updated.
```

corvette:CARS/CARSApp/src>diff -U1 ../../../xxx/xxxApp/src/Makefile .
--- ../../../xxx/xxxApp/src/Makefile    2017-09-06 13:15:55.131894728 -0500
+++ ./Makefile  2017-09-06 13:15:52.359914306 -0500
@@ -12,2 +12,26 @@

+LIBRARY_IOC += CARS
+
+# The following are compiled and added to the Support library
+CARS_SRCS += coordTrans2D.st
+CARS_SRCS += BMD_LVP_Detector.st
+CARS_SRCS += IDD_LVP_Detector.st
+CARS_SRCS += Energy_CC.st
+CARS_SRCS += Energy.st
+CARS_SRCS += GSE_MonoEnergy.st
+CARS_SRCS += tomoCollect.st
+CARS_SRCS += GSE_MonoSupport.cpp
+CARS_SRCS += BM13_Energy.st
+CARS_SRCS += Analyzer.st
+CARS_SRCS += newport_table.st
+CARS_SRCS += newport_table_support.c
+CARS_SRCS += splint.c
+CARS_SRCS_Linux   += testIpac.c
+CARS_SRCS_vxWorks += testIpac.c
+
+CARS_LIBS += seq pv $(EPICS_IOC_BASE_LIBS)
+# GSE_MonoSupport.cpp needs libxml2.  That is provided in ADSupport.
+-include $(ADCORE)/ADApp/commonLibraryMakefile
+
+
 #=============================
@@ -17,4 +41,4 @@
 # DBD_PREFIX is used by ADCORE to add dbd files
-PROD_NAME = xxx
-DBD_PREFIX = iocxxx
+PROD_NAME = CARSApp
+DBD_PREFIX = CARS
 PROD_IOC = $(PROD_NAME)
@@ -37,3 +61,3 @@
 ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
-  DBD_NAME  = $(DBD_PREFIX)Win64
+  DBD_NAME  = $(DBD_PREFIX)Win32
   WINDOWS_TARGET = YES
@@ -212,2 +236,7 @@

+ifdef TPMAC
+  $(DBD_NAME)_DBD += pmacAsynMotor.dbd
+  $(PROD_NAME)_LIBS := pmacAsynMotor pmacAsynIPPort $($(PROD_NAME)_LIBS)
+endif
+
 #ifdef FLY
@@ -217,2 +246,6 @@

+ifdef CARS
+  $(DBD_NAME)_DBD += CARSSupport.dbd
+  $(PROD_NAME)_LIBS := CARS $($(PROD_NAME)_LIBS)
+endif
```