### PR TITLE
remove extra characters in geometry

### DIFF
--- a/xxxApp/op/adl/ioc_motors.adl
+++ b/xxxApp/op/adl/ioc_motors.adl
@@ -265,7 +265,7 @@ composite {
 		x=254
 		y=80
 		width=112
-		height=24rs
+		height=24
 	}
 	clr=0
 	bclr=17


### PR DESCRIPTION
resolves this error: `invalid literal for int: '24rs'`