### PR TITLE
Modular Shell Commands

### DIFF
--- a/iocBoot/iocxxx/softioc/commands/console
+++ b/iocBoot/iocxxx/softioc/commands/console
@@ -1,0 +1,40 @@
+register "console" console
+
+console() {
+    if checkpid; then
+        case ${RUNNING_IN} in
+            procServ)
+                if [ ! -z ${SAME_HOST} ]; then
+                    # It is assumed that the port or socket have been read successfully from the info file
+                    if [ ${PROCSERV_ENDPOINT} == 'tcp' ]; then
+                        ${ECHO} "Connecting to ${IOC_NAME}'s procServ with ${TELNET}"
+                        ${TELNET} 127.0.0.1 ${PROCSERV_PORT}
+                    elif [ ${PROCSERV_ENDPOINT} == 'unix' ]; then
+                        ${ECHO} "Connecting to ${IOC_NAME}'s procServ with ${SOCAT}"
+                        cd ${IOC_STARTUP_DIR}
+                        ${SOCAT} -,rawer,echo=0 unix-connect:${PROCSERV_SOCKET}
+                    else
+                        ${ECHO} "Error: no procServ port or socket specified"
+                    fi
+                else
+                    # This could be smarter in the future
+                    ${ECHO} "Can't connect to the console; procServ is running on another computer"
+                fi
+            ;;
+            
+            screen)
+                ${ECHO} "Connecting to ${IOC_NAME}'s screen session"
+                # The -r flag will only connect if no one is attached to the session
+                #!${SCREEN} -r ${IOC_NAME}
+                # The -x flag will connect even if someone is attached to the session
+                ${SCREEN} -x ${IOC_NAME}
+            ;;
+            
+            * )
+                ${ECHO} "Can't connect to ${IOC_NAME}; it isn't running in screen or procServ"
+            ;;
+        esac
+    else
+        ${ECHO} "${IOC_NAME} is not running"
+    fi
+}

--- a/iocBoot/iocxxx/softioc/commands/restart
+++ b/iocBoot/iocxxx/softioc/commands/restart
@@ -1,0 +1,6 @@
+register "restart" restart
+
+restart() {
+    ioc_cmd stop
+    ioc_cmd start
+}

--- a/iocBoot/iocxxx/softioc/commands/run
+++ b/iocBoot/iocxxx/softioc/commands/run
@@ -7,7 +7,8 @@ run() {
     else
         ${ECHO} "Starting ${IOC_NAME}"
         cd ${IOC_STARTUP_DIR}
-        # Run xxx outside of a screen session, which is helpful for debugging
+		
+        # Run IOC outside of a screen session, which is helpful for debugging
         ${IOC_CMD}
     fi
 }

--- a/iocBoot/iocxxx/softioc/commands/run
+++ b/iocBoot/iocxxx/softioc/commands/run
@@ -1,0 +1,13 @@
+register "run" run
+
+run() {
+    if checkpid; then
+        ${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
+        screenpid
+    else
+        ${ECHO} "Starting ${IOC_NAME}"
+        cd ${IOC_STARTUP_DIR}
+        # Run xxx outside of a screen session, which is helpful for debugging
+        ${IOC_CMD}
+    fi
+}

--- a/iocBoot/iocxxx/softioc/commands/start
+++ b/iocBoot/iocxxx/softioc/commands/start
@@ -44,17 +44,17 @@ start() {
         
         case ${RUN_IN} in
             shell)
-                # Run xxx outside of a screen session, which is helpful for debugging
+                # Run IOC outside of a screen session, which is helpful for debugging
                 ${IOC_CMD}
             ;;
             
             screen)
-                # Run xxx inside a screen session
+                # Run IOC inside a screen session
                 ${SCREEN} -dm -S ${IOC_NAME} -h 5000 ${IOC_CMD}
             ;;
             
             procServ)
-                # Run xxx inside procServ
+                # Run IOC inside procServ
                 if [ ${PROCSERV_ENDPOINT} == 'tcp' ]; then
                     # Pick a random port, unless the script is configured to use a specific one
                     if [ ${PROCSERV_PORT} == '-1' -o -z ${PROCSERV_PORT} ]; then

--- a/iocBoot/iocxxx/softioc/commands/start
+++ b/iocBoot/iocxxx/softioc/commands/start
@@ -1,0 +1,88 @@
+register "start" start
+
+start() {
+	RUN_IN_ARG=$1
+	
+	# Allow the RUN_IN setting to be overridden on the command-line
+	if [ ! -z ${RUN_IN_ARG} ] ; then
+		case ${RUN_IN_ARG} in
+			shell)
+				RUN_IN=shell
+				echo "Overriding RUN_IN with shell"
+			;;
+	
+			screen)
+				RUN_IN=screen
+				echo "Overriding RUN_IN with screen"
+			;;
+			
+			procServ | ps)
+				RUN_IN=procServ
+				echo "Overriding RUN_IN with procServ"
+			;;
+			
+			iocConsole)
+				RUN_IN=iocConsole
+				echo "Overriding RUN_IN with iocConsole"
+			;;
+			
+			* )
+				# Use the default value of RUN_IN, if RUN_IN_ARG isn't valid
+				echo "RUN_IN_ARG isn't valid: ${RUN_IN_ARG}"
+			;;
+		esac
+	fi
+
+
+
+    if checkpid; then
+        ${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
+        screenpid
+    else
+        ${ECHO} "Starting ${IOC_NAME}"
+        cd ${IOC_STARTUP_DIR}
+        
+        case ${RUN_IN} in
+            shell)
+                # Run xxx outside of a screen session, which is helpful for debugging
+                ${IOC_CMD}
+            ;;
+            
+            screen)
+                # Run xxx inside a screen session
+                ${SCREEN} -dm -S ${IOC_NAME} -h 5000 ${IOC_CMD}
+            ;;
+            
+            procServ)
+                # Run xxx inside procServ
+                if [ ${PROCSERV_ENDPOINT} == 'tcp' ]; then
+                    # Pick a random port, unless the script is configured to use a specific one
+                    if [ ${PROCSERV_PORT} == '-1' -o -z ${PROCSERV_PORT} ]; then
+                        PROCSERV_PORT=$(get_random_port)
+                    fi
+                    
+                    # Start procServ with a tcp control endpoint
+                    ${PROCSERV} ${PROCSERV_OPTIONS} -i ^C --logoutcmd=^D -I ${PROCSERV_INFO_FILE} ${PROCSERV_PORT} ${IOC_CMD}
+                elif [ ${PROCSERV_ENDPOINT} == 'unix' ]; then
+                    # Pick a socket name, if it is commented out above
+                    if [ ! -z ${PROCSERV_SOCKET} ]; then
+                        PROCSERV_SOCKET=ioc${IOC_NAME}.socket
+                    fi
+                    
+                    # Start procServ with a unix socket control endpoint
+                    ${PROCSERV} ${PROCSERV_OPTIONS} -i ^C --logoutcmd=^D -I ${PROCSERV_INFO_FILE} unix:${PROCSERV_SOCKET} ${IOC_CMD}
+                else
+                    ${ECHO} "Can't start ${IOC_NAME} in procServ: PROCSERV_ENDPOINT has an invalid value: ${PROCSERV_ENDPOINT}"
+                fi
+            ;;
+            
+            * )
+                echo "Error: invalid value for RUN_IN: ${RUN_IN}"
+            ;;
+        esac
+    fi
+}
+
+start_usage() {
+	${ECHO} "$(${BASENAME} ${SNAME}) start {screen|procServ|ps|shell}"
+}

--- a/iocBoot/iocxxx/softioc/commands/start_caqtdm
+++ b/iocBoot/iocxxx/softioc/commands/start_caqtdm
@@ -1,5 +1,5 @@
 register "caqtdm" start_caqtdm
 
 start_caqtdm() {
-	${IOC_STARTUP_DIR}/../../start_caQtDM_xxx
+	${IOC_STARTUP_DIR}/../../start_caQtDM_$(IOC_NAME)
 }

--- a/iocBoot/iocxxx/softioc/commands/start_caqtdm
+++ b/iocBoot/iocxxx/softioc/commands/start_caqtdm
@@ -1,0 +1,5 @@
+register "caqtdm" start_caqtdm
+
+start_caqtdm() {
+	${IOC_STARTUP_DIR}/../../start_caQtDM_xxx
+}

--- a/iocBoot/iocxxx/softioc/commands/start_medm
+++ b/iocBoot/iocxxx/softioc/commands/start_medm
@@ -1,5 +1,5 @@
 register "medm" start_medm
 
 start_medm() {
-	${IOC_STARTUP_DIR}/../../start_MEDM_xxx
+	${IOC_STARTUP_DIR}/../../start_MEDM_$(IOC_NAME)
 }

--- a/iocBoot/iocxxx/softioc/commands/start_medm
+++ b/iocBoot/iocxxx/softioc/commands/start_medm
@@ -1,0 +1,5 @@
+register "medm" start_medm
+
+start_medm() {
+	${IOC_STARTUP_DIR}/../../start_MEDM_xxx
+}

--- a/iocBoot/iocxxx/softioc/commands/status
+++ b/iocBoot/iocxxx/softioc/commands/status
@@ -1,0 +1,10 @@
+register "status" status
+
+status() {
+    if checkpid; then
+        ${ECHO} -n "${IOC_NAME} is running (pid=${IOC_PID})"
+        screenpid
+    else
+        ${ECHO} "${IOC_NAME} is not running"
+    fi
+}

--- a/iocBoot/iocxxx/softioc/commands/stop
+++ b/iocBoot/iocxxx/softioc/commands/stop
@@ -1,0 +1,23 @@
+register "stop" stop
+
+stop() {
+    if checkpid; then
+        case ${RUNNING_IN} in
+            procServ)
+                if [ ! -z ${SAME_HOST} ]; then
+                    ${ECHO} "Stopping ${IOC_NAME} (procServ pid=${PROCSERV_PID})"
+                    ${KILL} ${PROCSERV_PID}
+                else
+                    ${ECHO} "Can't kill the IOC. It is running in procServ on a different computer."
+                fi
+            ;;
+            
+            * )
+                ${ECHO} "Stopping ${IOC_NAME} (pid=${IOC_PID})"
+                ${KILL} ${IOC_PID}
+            ;;
+        esac
+    else
+        ${ECHO} "${IOC_NAME} is not running"
+    fi
+}

--- a/iocBoot/iocxxx/softioc/commands/usage
+++ b/iocBoot/iocxxx/softioc/commands/usage
@@ -1,0 +1,36 @@
+register "usage" usage
+
+usage() {
+	if [ $# -eq 0 ] ; then
+		OUTPUT="Usage: $(${BASENAME} ${SNAME}) {"
+		
+		for i in "${REGISTERED_CMD_NAMES[@]}"; do
+			OUTPUT+="$i|"
+		done
+		
+		OUTPUT=`echo $OUTPUT | sed 's/.$//'`
+		
+		${ECHO} "$OUTPUT)"
+	else
+		CMD_CHECK=$1
+		VAL=0
+		
+		for i in "${REGISTERED_CMD_NAMES[@]}"; do
+			if [ $i == "$CMD_CHECK" ] ;  then
+				
+			
+				if [ `type -t ${REGISTERED_CMD_FUNCS[$VAL]}_usage`"" == 'function' ] ; then
+					${REGISTERED_CMD_FUNCS[$VAL]}_usage
+				else
+					${ECHO} "$(${BASENAME} ${SNAME}) $CMD_CHECK"
+				fi
+				
+				return
+			fi
+			
+			VAL=$((VAL+1))
+		done
+
+		${ECHO} "Command $CMD_CHECK not recognized"
+	fi
+}

--- a/iocBoot/iocxxx/softioc/xxx.sh
+++ b/iocBoot/iocxxx/softioc/xxx.sh
@@ -7,7 +7,7 @@
 #!IOC_STARTUP_DIR=/home/username/epics/ioc/synApps/xxx/iocBoot/iocxxx/softioc
 
 # Manually set IOC_COMMAND_DIR if xxx.sh will reside somewhere other than softioc
-#!IOC_STARTUP_DIR=/home/username/epics/ioc/synApps/xxx/iocBoot/iocxxx/softioc/commands
+#!IOC_COMMAND_DIR=/home/username/epics/ioc/synApps/xxx/iocBoot/iocxxx/softioc/commands
 
 
 # Set EPICS_HOST_ARCH if the env var isn't already set properly for this IOC
@@ -106,7 +106,7 @@ else
 fi
 #!${ECHO} ${IOC_STARTUP_DIR}
 
-if [ -x "$IOC_COMMAND_DIR" ] ; then
+if [ -z "$IOC_COMMAND_DIR" ] ; then
 	IOC_COMMAND_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/commands"
 fi
 

--- a/iocBoot/iocxxx/softioc/xxx.sh
+++ b/iocBoot/iocxxx/softioc/xxx.sh
@@ -6,6 +6,10 @@
 # Manually set IOC_STARTUP_DIR if xxx.sh will reside somewhere other than softioc
 #!IOC_STARTUP_DIR=/home/username/epics/ioc/synApps/xxx/iocBoot/iocxxx/softioc
 
+# Manually set IOC_COMMAND_DIR if xxx.sh will reside somewhere other than softioc
+#!IOC_STARTUP_DIR=/home/username/epics/ioc/synApps/xxx/iocBoot/iocxxx/softioc/commands
+
+
 # Set EPICS_HOST_ARCH if the env var isn't already set properly for this IOC
 #!EPICS_HOST_ARCH=linux-x86_64
 #!EPICS_HOST_ARCH=linux-x86_64-debug
@@ -102,8 +106,9 @@ else
 fi
 #!${ECHO} ${IOC_STARTUP_DIR}
 
-CMD_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/commands"
-
+if [ -x "$IOC_COMMAND_DIR" ] ; then
+	IOC_COMMAND_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/commands"
+fi
 
 # Variables used to calculatate a random port for procServ
 START=50000
@@ -347,7 +352,7 @@ ioc_cmd() {
 	${ECHO} "$CMD not a recognized command"
 }
 
-for file in ${CMD_DIR}/*; do
+for file in ${IOC_COMMAND_DIR}/*; do
 	source $file
 done
 


### PR DESCRIPTION
Changes the xxx.sh startup script to dynamically generate its own list of commands.

IOC_COMMAND_DIR is available to be set to point to a folder where the commands reside. If it isn't set, the script uses the 'commands' folder in the same folder as xxx.sh. When the script is run, it sources each of the files that are contained in the command directory. The files define shell functions and then bind them to a string with the line:

    register "COMMAND_NAME" shell_function

When you call xxx.sh now, it takes the first argument, tries to match it against a registered command name, then calls the shell_function for that name and passes that function all the additional command-line parameters (currently, only 'start' and 'usage' do anything with extra parameters though). Code is run in the same process as the xxx.sh script, so the commands have access to all the same environment variables.

As well, the usage command has been updated. The basic version runs through and builds a string list of all available commands and displays it to the user. If the script command is called with an additional parameter giving the name of a different command, it will attempt to find if there is a usage shell function for that command. The usage shell function is the same name as the actual function, just with "_usage" appended. For example, the start command has a usage function that displays the various inputs it can take in, the shell function for start is defined as start(), so the usage function is start_usage().

The usage script checks if that function exists, then calls it. If the command is a recognized command, but there is no usage function, it just displays that you call the command without any additional parameters. This allows commands that take in additional parameters to display information about how to use them, while keeping things simple for commands that are simple.

Finally, there is the ioc_cmd shell function added in for the commands to use. This allows the commands to call other commands without issues about which one gets loaded first. This is also the function that is used to find and run the commands based on the command line input. So far, only the restart command uses it.

Taken altogether, this is what a command file looks like:

    register "medm" start_medm
    
    start_medm() {
        ${IOC_STARTUP_DIR}/../../start_MEDM_xxx
    }

Throwing this out there because I've had IOC's before I have put extra commands in. It's not a difficult process to add an additional case statement and call a function, but with the increasing complexity and size of the xxx.sh script, breaking these out into more manageable pieces and automating the addition may make it more approachable for those with less knowledge of the bones of the script.


**Note**: This does change the script to explicitly using bash, I don't think that's a dealbreaker, but it is something to note.