### PR TITLE
define soft asynMotor HLS value

### DIFF
--- a/iocBoot/iocxxx/examples/motors.iocsh
+++ b/iocBoot/iocxxx/examples/motors.iocsh
@@ -3,7 +3,7 @@ dbLoadTemplate("substitutions/motor.substitutions", "P=$(PREFIX)")
 #dbLoadTemplate("substitutions/softMotor.substitutions", "P=$(PREFIX)")
 #dbLoadTemplate("substitutions/pseudoMotor.substitutions", "P=$(PREFIX)")
 
-#iocshLoad("$(MOTOR)/modules/motorMotorSim/iocsh/motorSim.iocsh", "INSTANCE=motorSim, HOME_POS=0, NUM_AXES=16, LOW_LIM=-32000, SUB=substitutions/motorSim.substitutions")
+#iocshLoad("$(MOTOR)/modules/motorMotorSim/iocsh/motorSim.iocsh", "INSTANCE=motorSim, HOME_POS=0, NUM_AXES=16, HIGH_LIM=32000, LOW_LIM=-32000, SUB=substitutions/motorSim.substitutions")
 
 # Allstop, alldone
 iocshLoad("$(MOTOR)/iocsh/allstop.iocsh", "P=$(PREFIX)")


### PR DESCRIPTION
FIX #46

Found the missing `HIGH_LIM` specification to be a problem while building a new docker image with synApps 6.2 and motor 7-2-2.  See https://github.com/prjemian/epics-docker/issues/23#issuecomment-774990195