### PR TITLE
Remote Shell Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ built_*.req
 dbl-all.txt
 *.sav*
 scan1Menu.sav
+iocBoot/*/softioc/logs

--- a/iocBoot/iocxxx/softioc/commands/console
+++ b/iocBoot/iocxxx/softioc/commands/console
@@ -1,40 +1,21 @@
 register "console" console
 
 console() {
-    if checkpid; then
-        case ${RUNNING_IN} in
-            procServ)
-                if [ ! -z ${SAME_HOST} ]; then
-                    # It is assumed that the port or socket have been read successfully from the info file
-                    if [ ${PROCSERV_ENDPOINT} == 'tcp' ]; then
-                        ${ECHO} "Connecting to ${IOC_NAME}'s procServ with ${TELNET}"
-                        ${TELNET} 127.0.0.1 ${PROCSERV_PORT}
-                    elif [ ${PROCSERV_ENDPOINT} == 'unix' ]; then
-                        ${ECHO} "Connecting to ${IOC_NAME}'s procServ with ${SOCAT}"
-                        cd ${IOC_STARTUP_DIR}
-                        ${SOCAT} -,rawer,echo=0 unix-connect:${PROCSERV_SOCKET}
-                    else
-                        ${ECHO} "Error: no procServ port or socket specified"
-                    fi
-                else
-                    # This could be smarter in the future
-                    ${ECHO} "Can't connect to the console; procServ is running on another computer"
-                fi
-            ;;
-            
-            screen)
-                ${ECHO} "Connecting to ${IOC_NAME}'s screen session"
-                # The -r flag will only connect if no one is attached to the session
-                #!${SCREEN} -r ${IOC_NAME}
-                # The -x flag will connect even if someone is attached to the session
-                ${SCREEN} -x ${IOC_NAME}
-            ;;
-            
-            * )
-                ${ECHO} "Can't connect to ${IOC_NAME}; it isn't running in screen or procServ"
-            ;;
-        esac
-    else
-        ${ECHO} "${IOC_NAME} is not running"
-    fi
+	if [[ $REMOTE_COMMAND == "YES" ]] ; then
+		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+			${TELNET} $(psinfo $INFO_CONSOLE $INFO_IP) $(psinfo $INFO_CONSOLE $INFO_PORT)
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
+	else
+		if checkpid; then
+			${ECHO} "Connecting to ${IOC_NAME}'s screen session"
+			# The -r flag will only connect if no one is attached to the session
+			#!${SCREEN} -r ${IOC_NAME}
+			# The -x flag will connect even if someone is attached to the session
+			${SCREEN} -x ${IOC_NAME}
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
+	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/console
+++ b/iocBoot/iocxxx/softioc/commands/console
@@ -1,21 +1,17 @@
 register "console" console
 
 console() {
-	if [[ $REMOTE_COMMAND == "YES" ]] ; then
-		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
-			${TELNET} $(psinfo $INFO_CONSOLE $INFO_IP) $(psinfo $INFO_CONSOLE $INFO_PORT)
-		else
-			${ECHO} "${IOC_NAME} is not running"
-		fi
+	if ! ioc_up; then
+		${ECHO} "${IOC_NAME} is not running"
+		
+	elif has_remote; then
+		${TELNET} $(psinfo $INFO_CONSOLE $INFO_IP) $(psinfo $INFO_CONSOLE $INFO_PORT)
+
 	else
-		if checkpid; then
-			${ECHO} "Connecting to ${IOC_NAME}'s screen session"
-			# The -r flag will only connect if no one is attached to the session
-			#!${SCREEN} -r ${IOC_NAME}
-			# The -x flag will connect even if someone is attached to the session
-			${SCREEN} -x ${IOC_NAME}
-		else
-			${ECHO} "${IOC_NAME} is not running"
-		fi
+		${ECHO} "Connecting to ${IOC_NAME}'s screen session"
+		# The -r flag will only connect if no one is attached to the session
+		#!${SCREEN} -r ${IOC_NAME}
+		# The -x flag will connect even if someone is attached to the session
+		${SCREEN} -x ${IOC_NAME}
 	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/remote
+++ b/iocBoot/iocxxx/softioc/commands/remote
@@ -31,13 +31,12 @@ remote() {
 		
 		ENDPOINT="${MY_IP}:$(get_random_port)"
 		INFO_FILE="$(psinfo $INFO_COMMAND $INFO_PREFIX).txt"
-		LOG_FILE="${SNAME}/logs/$(psinfo $INFO_COMMAND $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+		LOG_FILE="${SNAME}/logs/remote/$(psinfo $INFO_COMMAND $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
 		
 		# Start Command Port
-		${PROCSERV} ${PROCSERV_OPTIONS} --oneshot --quiet -L ${LOG_FILE} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${SNAME}/${IOC_NAME}.sh remote commandline
-	fi
+		${PROCSERV} --allow --oneshot --quiet -L ${LOG_FILE} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${SNAME}/${IOC_NAME}.sh remote commandline
 	
-	if [ $ONOFF == "disable" ] ; then
+	elif [ $ONOFF == "disable" ] ; then
 		if [[ $(psinfo $INFO_COMMAND $INFO_SAME_HOST) -ne 0 ]] ; then
 	
 			if [[ $(psinfo $INFO_COMMAND $INFO_PID) -ne -1 ]] ; then
@@ -51,12 +50,13 @@ remote() {
 		else
 			${ECHO} "Command console not running on this computer"
 		fi
-	fi
-	
-	if [ $ONOFF == "commandline" ] ; then
+		
+	elif [ $ONOFF == "commandline" ] ; then
 		${ECHO} -n "> "
 	
 		while IFS='$\n' read -ra line; do
+			
+			update_psinfo
 		
 			TEMP=($line)
 		
@@ -70,6 +70,8 @@ remote() {
 			
 			${ECHO} -n "> "
 		done
+	else
+		ioc_cmd usage remote
 	fi
 }
 

--- a/iocBoot/iocxxx/softioc/commands/remote
+++ b/iocBoot/iocxxx/softioc/commands/remote
@@ -1,0 +1,78 @@
+register "remote" remote
+
+get_random_port() {
+	# Variables used to calculatate a random port for procServ
+	START=50000
+	NUM_PORTS=100
+
+    # Get a random port for procServ
+    while :
+    do
+        i=$(( $RANDOM % $NUM_PORTS + $START ))
+        ${NC} -z localhost $i
+        if [ $? ]
+        then
+            echo "$i"
+            break
+        fi
+    done
+}
+
+remote() {
+	ONOFF=$1
+	
+	if [ $ONOFF == "enable" ] ; then
+		if [[ $(psinfo $INFO_COMMAND $INFO_PID) -ne -1 ]] ; then
+			${ECHO} "Command console already running at $(psinfo $INFO_COMMAND $INFO_IP):$(psinfo $INFO_COMMAND $INFO_PORT)"
+			return
+		fi
+	
+		MY_IP=`hostname -I`
+		
+		ENDPOINT="${MY_IP}:$(get_random_port)"
+		INFO_FILE="$(psinfo $INFO_COMMAND $INFO_PREFIX).txt"
+		LOG_FILE="${SNAME}/logs/$(psinfo $INFO_COMMAND $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+		
+		# Start Command Port
+		${PROCSERV} ${PROCSERV_OPTIONS} --oneshot --quiet -L ${LOG_FILE} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${SNAME}/${IOC_NAME}.sh remote commandline
+	fi
+	
+	if [ $ONOFF == "disable" ] ; then
+		if [[ $(psinfo $INFO_COMMAND $INFO_SAME_HOST) -ne 0 ]] ; then
+	
+			if [[ $(psinfo $INFO_COMMAND $INFO_PID) -ne -1 ]] ; then
+				send_command $INFO_COMMAND "exit"
+			fi
+		
+			if [[ $(psinfo $INFO_CONSOLE $INFO_PID) -ne -1 ]] ; then
+				remote_cmd stop
+			fi
+			
+		else
+			${ECHO} "Command console not running on this computer"
+		fi
+	fi
+	
+	if [ $ONOFF == "commandline" ] ; then
+		${ECHO} -n "> "
+	
+		while IFS='$\n' read -ra line; do
+		
+			TEMP=($line)
+		
+			if [[ ${#TEMP[@]} -eq 1 ]] ; then
+				if [ $line == "exit" ] ; then
+					break
+				fi
+			fi
+				
+			remote_cmd $line
+			
+			${ECHO} -n "> "
+		done
+	fi
+}
+
+remote_usage() {
+	${ECHO} "$(${BASENAME} ${0}) remote enable/disable"
+}

--- a/iocBoot/iocxxx/softioc/commands/restart
+++ b/iocBoot/iocxxx/softioc/commands/restart
@@ -2,12 +2,20 @@ register "restart" restart
 register "restart" remote_restart
 
 restart() {
-    ioc_cmd stop
-    ioc_cmd start
+	if ! ioc_up; then
+		${ECHO} "IOC isn't running"
+	
+	elif has_remote; then
+		send_command $INFO_COMMAND "start"
+
+	else
+		ioc_cmd stop
+		sleep 1.0
+		ioc_cmd start
+	fi
 }
 
 remote_restart() {
 	remote_cmd stop
-	sleep 1.0
 	remote_cmd start
 }

--- a/iocBoot/iocxxx/softioc/commands/restart
+++ b/iocBoot/iocxxx/softioc/commands/restart
@@ -1,6 +1,13 @@
 register "restart" restart
+register "restart" remote_restart
 
 restart() {
     ioc_cmd stop
     ioc_cmd start
+}
+
+remote_restart() {
+	remote_cmd stop
+	sleep 1.0
+	remote_cmd start
 }

--- a/iocBoot/iocxxx/softioc/commands/run
+++ b/iocBoot/iocxxx/softioc/commands/run
@@ -1,14 +1,22 @@
 register "run" run
 
 run() {
-    if checkpid; then
-        ${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
-        screenpid
-    else
-        ${ECHO} "Starting ${IOC_NAME}"
-        cd ${IOC_STARTUP_DIR}
+	if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+		${ECHO} -n "${IOC_NAME} is already running"
+	else
 		
-        # Run IOC outside of a screen session, which is helpful for debugging
-        ${IOC_CMD}
-    fi
+		if checkpid; then
+			${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
+			screenpid
+		else
+			${ECHO} "Starting ${IOC_NAME}"
+			cd ${IOC_STARTUP_DIR}
+			
+			# Run IOC outside of a screen session, which is helpful for debugging
+			${IOC_CMD}
+			
+			cd ${SNAME}
+		fi
+		
+	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/run
+++ b/iocBoot/iocxxx/softioc/commands/run
@@ -1,22 +1,21 @@
 register "run" run
 
 run() {
-	if [[ $REMOTE_CONSOLE == "YES" ]] ; then
-		${ECHO} -n "${IOC_NAME} is already running"
-	else
+	if ioc_up; then
+		${ECHO} "${IOC_NAME} is already running"
+	
+	elif has_remote; then
+		${ECHO} "IOC set up for remote commands"
 		
-		if checkpid; then
-			${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
-			screenpid
-		else
-			${ECHO} "Starting ${IOC_NAME}"
-			cd ${IOC_STARTUP_DIR}
-			
-			# Run IOC outside of a screen session, which is helpful for debugging
-			${IOC_CMD}
-			
-			cd ${SNAME}
-		fi
+	else
+
+		${ECHO} "Starting ${IOC_NAME}"
+		cd ${IOC_STARTUP_DIR}
+		
+		# Run IOC outside of a screen session, which is helpful for debugging
+		${IOC_CMD}
+		
+		cd ${SNAME}
 		
 	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/start
+++ b/iocBoot/iocxxx/softioc/commands/start
@@ -1,103 +1,44 @@
 register "start" start
+register "start" remote_start remote
 
 start() {
-	PASSED_ARGS=$@
-	
-	while getopts "f" ARG; do
-		case "$ARG" in
-			f)  if [ -f "${IOC_STARTUP_DIR}/${PROCSERV_INFO_FILE}" ]; then
-					echo "Removing ${IOC_STARTUP_DIR}/${PROCSERV_INFO_FILE}"
-					rm -f ${IOC_STARTUP_DIR}/${PROCSERV_INFO_FILE}
-				fi
-			;;
-		esac
-	done
-	
-	shift "$((OPTIND-1))"	
-	
-	RUN_IN_ARG=$1
-	
-	# Allow the RUN_IN setting to be overridden on the command-line
-	if [ ! -z ${RUN_IN_ARG} ] ; then
-		case ${RUN_IN_ARG} in
-			shell)
-				RUN_IN=shell
-				echo "Overriding RUN_IN with shell"
-			;;
-	
-			screen)
-				RUN_IN=screen
-				echo "Overriding RUN_IN with screen"
-			;;
+	if [[ $REMOTE_COMMAND == "YES" ]] ; then	
+		
+		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+			${ECHO} "IOC already running"
+		else
+			send_command $INFO_COMMAND "start"
+		fi
+		
+	else
+		
+		if checkpid; then
+			${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
+			screenpid
+		else
+			${ECHO} "Starting ${IOC_NAME}"
 			
-			procServ | ps)
-				RUN_IN=procServ
-				echo "Overriding RUN_IN with procServ"
-			;;
+			LOG_FILE="${SNAME}/logs/${PROCSERV_INFO[$INFO_CONSOLE + $INFO_PREFIX]}.log_"`date +%y%m%d-%H%M%S`
 			
-			iocConsole)
-				RUN_IN=iocConsole
-				echo "Overriding RUN_IN with iocConsole"
-			;;
-			
-			* )
-				# Use the default value of RUN_IN, if RUN_IN_ARG isn't valid
-				echo "RUN_IN_ARG isn't valid: ${RUN_IN_ARG}"
-			;;
-		esac
+			cd ${IOC_STARTUP_DIR}
+			${SCREEN} -dm -S ${IOC_NAME} -h 5000 -L -Logfile ${LOG_FILE} ${IOC_CMD}
+			cd ${SNAME}
+		fi
+	
 	fi
-
-
-
-    if checkpid; then
-        ${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
-        screenpid
-    else
-        ${ECHO} "Starting ${IOC_NAME}"
-        cd ${IOC_STARTUP_DIR}
-        
-        case ${RUN_IN} in
-            shell)
-                # Run IOC outside of a screen session, which is helpful for debugging
-                ${IOC_CMD}
-            ;;
-            
-            screen)
-                # Run IOC inside a screen session
-                ${SCREEN} -dm -S ${IOC_NAME} -h 5000 ${IOC_CMD}
-            ;;
-            
-            procServ)
-                # Run IOC inside procServ
-                if [ ${PROCSERV_ENDPOINT} == 'tcp' ]; then
-                    # Pick a random port, unless the script is configured to use a specific one
-                    if [ ${PROCSERV_PORT} == '-1' -o -z ${PROCSERV_PORT} ]; then
-                        PROCSERV_PORT=$(get_random_port)
-                    fi
-                    
-                    # Start procServ with a tcp control endpoint
-                    ${PROCSERV} ${PROCSERV_OPTIONS} -i ^C --logoutcmd=^D -I ${PROCSERV_INFO_FILE} ${PROCSERV_PORT} ${IOC_CMD}
-                elif [ ${PROCSERV_ENDPOINT} == 'unix' ]; then
-                    # Pick a socket name, if it is commented out above
-                    if [ ! -z ${PROCSERV_SOCKET} ]; then
-                        PROCSERV_SOCKET=ioc${IOC_NAME}.socket
-                    fi
-                    
-                    # Start procServ with a unix socket control endpoint
-                    ${PROCSERV} ${PROCSERV_OPTIONS} -i ^C --logoutcmd=^D -I ${PROCSERV_INFO_FILE} unix:${PROCSERV_SOCKET} ${IOC_CMD}
-                else
-                    ${ECHO} "Can't start ${IOC_NAME} in procServ: PROCSERV_ENDPOINT has an invalid value: ${PROCSERV_ENDPOINT}"
-                fi
-            ;;
-            
-            * )
-                echo "Error: invalid value for RUN_IN: ${RUN_IN}"
-            ;;
-        esac
-    fi
 }
 
-start_usage() {
-	${ECHO} "$(${BASENAME} ${0}) start [-f] {screen|procServ|ps|shell}"
-	${ECHO} -e "\t-f \t Force start even if procinfo file exists"
+
+remote_start() {
+	MY_IP=`hostname -I`
+	ENDPOINT="${MY_IP}:$(get_random_port)"
+	INFO_FILE="$(psinfo $INFO_CONSOLE $INFO_PREFIX).txt"
+	LOG_FILE="${SNAME}/logs/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+	
+	# Start Console Port
+	${PROCSERV} ${PROCSERV_OPTIONS} --quiet --oneshot -L ${LOG_FILE} -c ${IOC_STARTUP_DIR} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${IOC_CMD}
+	
+	sleep 0.5
+	
+	parse_procServ_info $INFO_CONSOLE
 }

--- a/iocBoot/iocxxx/softioc/commands/start
+++ b/iocBoot/iocxxx/softioc/commands/start
@@ -22,13 +22,18 @@ start() {
 
 
 remote_start() {
-	MY_IP=`hostname -I`
-	ENDPOINT="${MY_IP}:$(get_random_port)"
-	INFO_FILE="$(psinfo $INFO_CONSOLE $INFO_PREFIX).txt"
-	LOG_FILE="${SNAME}/logs/iocConsole/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+	if ioc_up; then
+		${ECHO} -n "IOC is already running"
 	
-	# Start Console Port
-	${PROCSERV} --allow --quiet --oneshot -L ${LOG_FILE} -c ${IOC_STARTUP_DIR} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${IOC_CMD}
-	
-	sleep 0.5
+	else
+		MY_IP=`hostname -I`
+		ENDPOINT="${MY_IP}:$(get_random_port)"
+		INFO_FILE="$(psinfo $INFO_CONSOLE $INFO_PREFIX).txt"
+		LOG_FILE="${SNAME}/logs/iocConsole/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+		
+		# Start Console Port
+		${PROCSERV} --allow --quiet --oneshot -L ${LOG_FILE} -c ${IOC_STARTUP_DIR} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${IOC_CMD}
+		
+		sleep 0.5
+	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/start
+++ b/iocBoot/iocxxx/softioc/commands/start
@@ -2,29 +2,21 @@ register "start" start
 register "start" remote_start remote
 
 start() {
-	if [[ $REMOTE_COMMAND == "YES" ]] ; then	
-		
-		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
-			${ECHO} "IOC already running"
-		else
-			send_command $INFO_COMMAND "start"
-		fi
+	if ioc_up; then
+		${ECHO} -n "IOC is already running"
+	
+	elif has_remote ; then
+		send_command $INFO_COMMAND "start"
 		
 	else
 		
-		if checkpid; then
-			${ECHO} -n "${IOC_NAME} is already running (pid=${IOC_PID})"
-			screenpid
-		else
-			${ECHO} "Starting ${IOC_NAME}"
+		${ECHO} "Starting ${IOC_NAME}"
 			
-			LOG_FILE="${SNAME}/logs/${PROCSERV_INFO[$INFO_CONSOLE + $INFO_PREFIX]}.log_"`date +%y%m%d-%H%M%S`
+		LOG_FILE="${SNAME}/logs/iocConsole/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
 			
-			cd ${IOC_STARTUP_DIR}
-			${SCREEN} -dm -S ${IOC_NAME} -h 5000 -L -Logfile ${LOG_FILE} ${IOC_CMD}
-			cd ${SNAME}
-		fi
-	
+		cd ${IOC_STARTUP_DIR}
+		${SCREEN} -dm -S ${IOC_NAME} -h 5000 -L -Logfile ${LOG_FILE} ${IOC_CMD}
+		cd ${SNAME}
 	fi
 }
 
@@ -33,12 +25,10 @@ remote_start() {
 	MY_IP=`hostname -I`
 	ENDPOINT="${MY_IP}:$(get_random_port)"
 	INFO_FILE="$(psinfo $INFO_CONSOLE $INFO_PREFIX).txt"
-	LOG_FILE="${SNAME}/logs/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
+	LOG_FILE="${SNAME}/logs/iocConsole/$(psinfo $INFO_CONSOLE $INFO_PREFIX).log_"`date +%y%m%d-%H%M%S`
 	
 	# Start Console Port
-	${PROCSERV} ${PROCSERV_OPTIONS} --quiet --oneshot -L ${LOG_FILE} -c ${IOC_STARTUP_DIR} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${IOC_CMD}
+	${PROCSERV} --allow --quiet --oneshot -L ${LOG_FILE} -c ${IOC_STARTUP_DIR} -i ^C --logoutcmd=^D -I "${INFO_FILE}" "${ENDPOINT}" ${IOC_CMD}
 	
 	sleep 0.5
-	
-	parse_procServ_info $INFO_CONSOLE
 }

--- a/iocBoot/iocxxx/softioc/commands/status
+++ b/iocBoot/iocxxx/softioc/commands/status
@@ -1,10 +1,37 @@
 register "status" status
 
 status() {
-    if checkpid; then
-        ${ECHO} -n "${IOC_NAME} is running (pid=${IOC_PID})"
-        screenpid
-    else
-        ${ECHO} "${IOC_NAME} is not running"
+	if [[ $REMOTE_COMMAND == "YES" ]] ; then
+		IP=`psinfo $INFO_COMMAND $INFO_IP`
+		PORT=`psinfo $INFO_COMMAND $INFO_PORT`
+		
+		if [[ $(psinfo $INFO_COMMAND $INFO_SAME_HOST) -ne 0 ]] ; then
+			${ECHO} "Command console running locally on port $PORT"
+		else
+			${ECHO} "Command console running remotely at $IP:$PORT"
+		fi
+	
+		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+			IP=`psinfo $INFO_CONSOLE $INFO_IP`
+			PORT=`psinfo $INFO_CONSOLE $INFO_PORT`
+			PID=`psinfo $INFO_CONSOLE $INFO_PID`
+		
+			if [[ $(psinfo $INFO_CONSOLE $INFO_SAME_HOST) -ne 0 ]] ; then
+				${ECHO} "${IOC_NAME} is running locally on port $PORT (pid=$PID)"
+			else
+				${ECHO} "IOC console is running remotely at $IP:$PORT (pid=$PID)"
+			fi
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
+		
+	else
+	
+		if checkpid; then
+			${ECHO} -n "${IOC_NAME} is running locally (pid=${IOC_PID})"
+			screenpid
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
     fi
 }

--- a/iocBoot/iocxxx/softioc/commands/status
+++ b/iocBoot/iocxxx/softioc/commands/status
@@ -1,37 +1,35 @@
 register "status" status
 
 status() {
-	if [[ $REMOTE_COMMAND == "YES" ]] ; then
+
+	if has_remote; then
 		IP=`psinfo $INFO_COMMAND $INFO_IP`
 		PORT=`psinfo $INFO_COMMAND $INFO_PORT`
 		
-		if [[ $(psinfo $INFO_COMMAND $INFO_SAME_HOST) -ne 0 ]] ; then
+		if is_local; then
 			${ECHO} "Command console running locally on port $PORT"
 		else
 			${ECHO} "Command console running remotely at $IP:$PORT"
 		fi
+	fi
+
+	if ioc_up; then
+		if is_local; then
+			${ECHO} -n "${IOC_NAME} is running locally "
+		else
+			${ECHO} -n "${IOC_NAME} is running remotely "
+		fi
 	
-		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+		if has_remote; then
 			IP=`psinfo $INFO_CONSOLE $INFO_IP`
 			PORT=`psinfo $INFO_CONSOLE $INFO_PORT`
-			PID=`psinfo $INFO_CONSOLE $INFO_PID`
-		
-			if [[ $(psinfo $INFO_CONSOLE $INFO_SAME_HOST) -ne 0 ]] ; then
-				${ECHO} "${IOC_NAME} is running locally on port $PORT (pid=$PID)"
-			else
-				${ECHO} "IOC console is running remotely at $IP:$PORT (pid=$PID)"
-			fi
+			
+			${ECHO} "at $IP:$PORT (pid=$(psinfo $INFO_CONSOLE $INFO_PID))"
 		else
-			${ECHO} "${IOC_NAME} is not running"
+			screenpid
 		fi
 		
 	else
-	
-		if checkpid; then
-			${ECHO} -n "${IOC_NAME} is running locally (pid=${IOC_PID})"
-			screenpid
-		else
-			${ECHO} "${IOC_NAME} is not running"
-		fi
-    fi
+		${ECHO} "${IOC_NAME} is not running"
+	fi
 }

--- a/iocBoot/iocxxx/softioc/commands/stop
+++ b/iocBoot/iocxxx/softioc/commands/stop
@@ -2,26 +2,36 @@ register "stop" stop
 register "stop" remote_stop remote
 
 stop() {
-	if [[ $REMOTE_COMMAND == "YES" ]] ; then
-
-		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
-			send_command $INFO_COMMAND "stop"
-		else
-			${ECHO} "${IOC_NAME} is not running"
-		fi
+	if ! ioc_up; then
+		${ECHO} "${IOC_NAME} is not running"
+	
+	elif has_remote; then
+		send_command $INFO_COMMAND "stop"
 		
 	else
-
-		if checkpid; then
-			${ECHO} "Stopping ${IOC_NAME} (pid=${IOC_PID})"
-			${KILL} ${IOC_PID}
-		else
-			${ECHO} "${IOC_NAME} is not running"
-		fi
+		checkpid
+		${ECHO} "Stopping ${IOC_NAME} (pid=${IOC_PID})"
+		${KILL} ${IOC_PID}
 		
 	fi
 }
 
 remote_stop() {
+	CHECK_PID=$(psinfo $INFO_CONSOLE $INFO_PID)
+
 	send_command $INFO_CONSOLE "exit"
+	
+	sleep 1.0
+	
+	WAIT=1
+	
+	while [[ ! -z `${PS} aux | ${GREP} "${CHECK_PID}" | ${GREP} "${IOC_CMD}"` ]] ; do		
+		if [[ $WAIT -eq 5 ]] ; then
+			${KILL} ${CHECK_PID}
+			break
+		fi
+
+		sleep 1.0
+		WAIT=`expr $WAIT + 1`
+	done
 }

--- a/iocBoot/iocxxx/softioc/commands/stop
+++ b/iocBoot/iocxxx/softioc/commands/stop
@@ -1,23 +1,27 @@
 register "stop" stop
+register "stop" remote_stop remote
 
 stop() {
-    if checkpid; then
-        case ${RUNNING_IN} in
-            procServ)
-                if [ ! -z ${SAME_HOST} ]; then
-                    ${ECHO} "Stopping ${IOC_NAME} (procServ pid=${PROCSERV_PID})"
-                    ${KILL} ${PROCSERV_PID}
-                else
-                    ${ECHO} "Can't kill the IOC. It is running in procServ on a different computer."
-                fi
-            ;;
-            
-            * )
-                ${ECHO} "Stopping ${IOC_NAME} (pid=${IOC_PID})"
-                ${KILL} ${IOC_PID}
-            ;;
-        esac
-    else
-        ${ECHO} "${IOC_NAME} is not running"
-    fi
+	if [[ $REMOTE_COMMAND == "YES" ]] ; then
+
+		if [[ $REMOTE_CONSOLE == "YES" ]] ; then
+			send_command $INFO_COMMAND "stop"
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
+		
+	else
+
+		if checkpid; then
+			${ECHO} "Stopping ${IOC_NAME} (pid=${IOC_PID})"
+			${KILL} ${IOC_PID}
+		else
+			${ECHO} "${IOC_NAME} is not running"
+		fi
+		
+	fi
+}
+
+remote_stop() {
+	send_command $INFO_CONSOLE "exit"
 }

--- a/iocBoot/iocxxx/softioc/commands/usage
+++ b/iocBoot/iocxxx/softioc/commands/usage
@@ -1,5 +1,5 @@
 register "usage" usage
-register "usage" remote_usage remote
+register "usage" usage_remote remote
 
 usage() {
 	if [ $# -eq 0 ] ; then
@@ -36,7 +36,7 @@ usage() {
 	fi
 }
 
-remote_usage() {
+usage_remote() {
 	if [ $# -eq 0 ] ; then
 		OUTPUT="Usage: {"
 		

--- a/iocBoot/iocxxx/softioc/commands/usage
+++ b/iocBoot/iocxxx/softioc/commands/usage
@@ -1,4 +1,5 @@
 register "usage" usage
+register "usage" remote_usage remote
 
 usage() {
 	if [ $# -eq 0 ] ; then
@@ -23,6 +24,41 @@ usage() {
 					${REGISTERED_CMD_FUNCS[$VAL]}_usage
 				else
 					${ECHO} "$(${BASENAME} $0) $CMD_CHECK"
+				fi
+				
+				return
+			fi
+			
+			VAL=$((VAL+1))
+		done
+
+		${ECHO} "Command $CMD_CHECK not recognized"
+	fi
+}
+
+remote_usage() {
+	if [ $# -eq 0 ] ; then
+		OUTPUT="Usage: {"
+		
+		for i in "${REMOTE_CMD_NAMES[@]}"; do
+			OUTPUT+="$i|"
+		done
+		
+		OUTPUT=`echo $OUTPUT | sed 's/.$//'`
+		
+		${ECHO} "$OUTPUT}"
+	else
+		CMD_CHECK=$1
+		VAL=0
+		
+		for i in "${REMOTE_CMD_NAMES[@]}"; do
+			if [ $i == "$CMD_CHECK" ] ;  then
+				
+			
+				if [ `type -t ${REMOTE_CMD_FUNCS[$VAL]}_usage`"" == 'function' ] ; then
+					${REMOTE_CMD_FUNCS[$VAL]}_usage
+				else
+					${ECHO} "$CMD_CHECK"
 				fi
 				
 				return

--- a/xxxApp/op/adl/ioc_optics.adl
+++ b/xxxApp/op/adl/ioc_optics.adl
@@ -484,9 +484,14 @@ composite {
 		width=112
 		height=24
 	}
+	display[0] {
+		label="EPID"
+		name="fb_epid.adl"
+		args="P=$(P):epid1"
+	}
 	clr=0
 	bclr=17
-	label="-"
+	label="-EPID"
 }
 "related display" {
 	object {

--- a/xxxApp/op/ui/xxx.ui
+++ b/xxxApp/op/ui/xxx.ui
@@ -170,7 +170,7 @@ QTabBar::tab:selected
 QWidget[Fill=&quot;True&quot;] { background: rgba(0,0,0,0); }</string>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="tab">
           <property name="Fill" stdset="0">
@@ -972,7 +972,7 @@ QWidget[Fill=&quot;True&quot;] { background: rgba(0,0,0,0); }</string>
            <item row="1" column="2">
             <widget class="caRelatedDisplay" name="carelateddisplay_47">
              <property name="label">
-              <string notr="true">-</string>
+              <string notr="true">-   EPID   </string>
              </property>
              <property name="foreground">
               <color>
@@ -987,6 +987,15 @@ QWidget[Fill=&quot;True&quot;] { background: rgba(0,0,0,0); }</string>
                <green>132</green>
                <blue>0</blue>
               </color>
+             </property>
+             <property name="labels">
+              <string>EPID #1</string>
+             </property>
+             <property name="files">
+              <string>fb_epid.ui</string>
+             </property>
+             <property name="args">
+              <string>P=xxx:epid1</string>
              </property>
              <property name="stackingMode" stdset="0">
               <enum>caRowColMenu::Menu</enum>


### PR DESCRIPTION
Splits out procServ support into a 'remote' command. Adds in a basic command shell to allow remote management commands. Users on the same subnet can trigger an IOC to start/stop/restart and access the console.

Usage:

On the computer where the IOC should be run:
> xxx.sh remote enable

Then, any computer on the subnet can run
> xxx.sh start