### PR TITLE
Add PVAServerRegister.dbd and link PVA core libs

### DIFF
--- a/xxxApp/src/Makefile
+++ b/xxxApp/src/Makefile
@@ -600,9 +600,13 @@ endif
 endif
 
 
-$(DBD_NAME)_DBD += qsrv.dbd
-
-$(PROD_NAME)_LIBS := qsrv $($(PROD_NAME)_LIBS)
+# pvAccess server
+ifdef EPICS_QSRV_MAJOR_VERSION
+  $(DBD_NAME)_DBD += qsrv.dbd
+  $(DBD_NAME)_DBD += PVAServerRegister.dbd
+  $(PROD_NAME)_LIBS := qsrv $($(PROD_NAME)_LIBS)
+  $(PROD_NAME)_LIBS += $(EPICS_BASE_PVA_CORE_LIBS)
+endif
 
 $(PROD_NAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
 


### PR DESCRIPTION
`qsrv` was added in 68e971c, however for it to work, PVAServerRegister.dbd and the libraries `$(EPICS_BASE_PVA_CORE_LIBS)` must also be added. Out of the box, `qsrv` in an xxx IOC works, but only because the missing .dbd and libs are included in the ADCore `commonDriverMakefile`, which is included here:
https://github.com/epics-modules/xxx/blob/6bc62254c7ba9a3bc78c7e656d583ff6bce5c312/xxxApp/src/Makefile#L47-L50

Relevant section in `commonDriverMakefile`:
https://github.com/areaDetector/ADCore/blob/6c53844e72d467b86a03fe712ea1f69210e2cae0/ADApp/commonDriverMakefile#L26-L38

It is not obvious (or probably intentional) that `qsrv` in xxx relies on ADCore. This PR fixes this.
See also: https://github.com/epics-base/pva2pva/issues/57